### PR TITLE
Allow data reduction for data with no b/offs using modified pattern removal.  Restore ability to generate wavelength solutions from ThAr arc lamp.

### DIFF
--- a/igrins/igrins_libs/obs_set.py
+++ b/igrins/igrins_libs/obs_set.py
@@ -108,6 +108,27 @@ class ObsSet(object):
 
             return obsids
 
+    def get_obsids_string(self):
+         obsids_list = self.get_obsids()
+         obsids_string = ''
+         n = len(obsids_list)
+         for i in range(n):
+             obsids_string += str(obsids_list[i])
+             if i < n-1:
+                 obsids_string += ', '
+         return obsids_string
+ 
+     def get_frametypes_string(self):
+         frametypes_list = self.frametypes
+         frametypes_string = ''
+         n = len(frametypes_list)
+         for i in range(n):
+             frametypes_string += frametypes_list[i]
+             if i < n-1:
+                 frametypes_string += ', '
+         return frametypes_string
+            
+
     def get_subset(self, *frametypes):
         ofs = [(o, f) for o, f in zip(self.obsids, self.frametypes)
                if f in frametypes]

--- a/igrins/igrins_libs/recipes.py
+++ b/igrins/igrins_libs/recipes.py
@@ -291,10 +291,10 @@ def load_recipe_as_dict(fn):
     #           ('GROUP1', 'S128'), ('GROUP2', 'S128'),
     #           ('EXPTIME', 'f'), ('RECIPE', 'S128'),
     #           ('OBSIDS', 'S1024'),  ('FRAMETYPES', 'S1024')]
-    dtypes = [('OBJNAME', np.unicode_), ('OBJTYPE', np.unicode_),
-              ('GROUP1', np.unicode_), ('GROUP2', np.unicode_),
-              ('EXPTIME', 'f'), ('RECIPE', np.unicode_),
-              ('OBSIDS', np.unicode_),  ('FRAMETYPES', np.unicode_)]
+    dtypes = [('OBJNAME', np.str_), ('OBJTYPE', np.str_),
+              ('GROUP1', np.str_), ('GROUP2', np.str_),
+              ('EXPTIME', 'f'), ('RECIPE', np.str_),
+              ('OBSIDS', np.str_),  ('FRAMETYPES', np.str_)]
 
     df = pd.read_csv(fn, skiprows=0, dtype=dtypes, comment="#",
                      escapechar="\\", skipinitialspace=True,

--- a/igrins/igrins_libs/storage_descriptions.py
+++ b/igrins/igrins_libs/storage_descriptions.py
@@ -63,6 +63,10 @@ COMBINED_VARIANCE0_DESC = ("OUTDATA_PATH",
                            "{basename}{postfix}.combined_variance0.fits")
 INTERORDER_BACKGROUND_DESC = ("OUTDATA_PATH",
                               "{basename}{postfix}.interorder_background.fits")
+DATA_MINUS_RAW_DESC = ("OUTDATA_PATH", "{basename}{postfix}.data_minus_raw.fits")
+DATA_PLUS_DESC = ("OUTDATA_PATH", "{basename}{postfix}.data_plus.fits")
+
+
 
 SLITPROFILE_FITS_DESC = ("OUTDATA_PATH",
                         "{basename}{postfix}.slitprofile.fits")

--- a/igrins/igrins_recipes/__init__.py
+++ b/igrins/igrins_recipes/__init__.py
@@ -1,7 +1,10 @@
 import importlib
 
 translation_map = {"wvlsol-sky": "wvlsol",
-                   "register-sky": "register"}
+                   "register-sky": "register",
+                   "register-thar": "register",
+                   "wvlsol-thar": "wvlsol",
+                   }
 
 def get_pipeline_steps(recipe_name,
                        parent_module_name="igrins.igrins_recipes"):

--- a/igrins/igrins_recipes/arghed_recipes.py
+++ b/igrins/igrins_recipes/arghed_recipes.py
@@ -40,7 +40,15 @@ def get_recipe_list():
                    create_argh_command("combine-sky", ["SKY", "SKY_AB"]),
                    create_argh_command("register-dry", ["FLAT"]),
                    create_argh_command("register-sky", ["SKY", "SKY_AB"]),
+
+                   create_argh_command("register-thar", ["THAR"]),
+
+
                    create_argh_command("wvlsol-sky", ["SKY", "SKY_AB"]),
+
+                   create_argh_command("wvlsol-thar", ["THAR"]),
+
+
                    create_argh_command("wvlsol-dry", ["FLAT"]),
                    create_argh_command("extract-sky", ["SKY", "SKY_AB"]),
                    create_argh_command("extract-arc", ["ARC_*"]),

--- a/igrins/igrins_recipes/recipe_combine.py
+++ b/igrins/igrins_recipes/recipe_combine.py
@@ -349,8 +349,40 @@ def make_combined_images(obsset, allow_no_b_frame=False,
         # dp = data_plus
         d2 = destriper.get_destriped(d2, mask=destripe_mask, pattern=64, hori=True, remove_vertical=False)
     else:
-        d2 = data_minus_raw
-        dp = data_plus
+        #d2 = data_minus_raw
+        #dp = data_plus
+
+
+
+
+
+
+        from ..procedures.estimate_sky import (estimate_background,
+                                   get_interpolated_cubic)
+
+
+
+
+        d2 = remove_pattern(data_minus_raw, remove_level=1,
+                            remove_amp_wise_var=False)
+        dp = remove_pattern(data_plus, remove_level=1,
+                            remove_amp_wise_var=False)
+
+        #Estimate and remove sky background
+        helper = ResourceHelper(obsset)
+        sky_mask = helper.get("sky_mask")
+
+        di = 24
+        min_pixel = 40
+        xc, yc, v, std = estimate_background(d2, sky_mask,
+                                             di=di, min_pixel=min_pixel)
+        
+        nx = ny = 2048
+        ZI3 = get_interpolated_cubic(nx, ny, xc, yc, v)
+        ZI3 = np.nan_to_num(ZI3)
+
+        # d2 -= ZI3
+        # dp -= ZI3
 
 
 

--- a/igrins/igrins_recipes/recipe_combine.py
+++ b/igrins/igrins_recipes/recipe_combine.py
@@ -336,6 +336,13 @@ def make_combined_images(obsset, allow_no_b_frame=False,
     obsset_b = obsset.get_subset("B", "OFF")
     na, nb = len(obsset_a.obsids), len(obsset_b.obsids)
 
+    #For making readout pattern removal plots, should normally be commented out
+    cache_only = False
+    hdul = obsset.get_hdul_to_write(([], data_minus_raw))
+    obsset.store("data_minus_raw", data=hdul, cache_only=cache_only)
+    hdul = obsset.get_hdul_to_write(([], data_plus))
+    obsset.store("data_plus", data=hdul, cache_only=cache_only)
+
 
     disable_pattern_removal = obsset.get_recipe_parameter("disable_pattern_removal") #Let user disable the pattern removal
     if nb > 0 and disable_pattern_removal==False:

--- a/igrins/igrins_recipes/recipe_combine.py
+++ b/igrins/igrins_recipes/recipe_combine.py
@@ -87,7 +87,7 @@ def _get_combined_image(obsset, no_b=False):
             for i in range(n_frames):
                 data_without_overscan = data_list[i][4:-4, 4:-4] #Cut overscan
                 if band == 'H':
-                    cr_mask, cr_array  = astroscrappy.detect_cosmics(data_without_overscan, gain=2.05, readnoise=10.92*readnoise_multiplier, sigclip = cosmics_sigmaclip, sigfrac = cosmics_sigfrac, objlim = cosmcis_objlim, niter=4, verbose=True, cleantype='fpatt') # Build the object for H-band
+                    cr_mask, cr_array  = astroscrappy.detect_cosmics(data_without_overscan, gain=2.05, readnoise=10.92*readnoise_multiplier, sigclip = cosmics_sigmaclip, sigfrac = cosmics_sigfrac, objlim = cosmcis_objlim, niter=4, verbose=True, cleantype='medmask') # Build the object for H-band
                 else: #if band == 'K'
                     cr_mask, cr_array  = astroscrappy.detect_cosmics(data_without_overscan, gain=2.21, readnoise=8.93*readnoise_multiplier, sigclip = cosmics_sigmaclip, sigfrac = cosmics_sigfrac, objlim = cosmcis_objlim, niter=4, verbose=True, cleantype='medmask') # Build the object for K-band            
                 dilated_cr_mask = binary_dilation(cr_mask, iterations=1)

--- a/igrins/igrins_recipes/recipe_extract.py
+++ b/igrins/igrins_recipes/recipe_extract.py
@@ -94,6 +94,7 @@ _steps_default = [
          order_range="-1,-1",
          correct_flexure=False,
          mask_cosmics=False,
+         disable_pattern_removal=False,
          ),
     Step("Set basename-postfix", set_basename_postfix,
          basename_postfix=""),

--- a/igrins/igrins_recipes/recipe_prepare_recipe_logs.py
+++ b/igrins/igrins_recipes/recipe_prepare_recipe_logs.py
@@ -10,6 +10,7 @@ from ..external import argh
 
 
 _default_recipe_name = dict(flat="FLAT", std="A0V_AB", tar="STELLAR_AB",
+                            sky='SKY',
                             dark="DARK",
                             arc_thar="ARC", arc_une="ARC")
 
@@ -48,6 +49,10 @@ def make_recipe_logs(obsdate, l, populate_group1=False,
 
         obsids = " ".join(group["OBSID"].apply(str))
         frametypes = " ".join(group["FRAMETYPE"])
+
+        if objtype.lower() == 'sky' or objname=='Blank sky' or objname=='SKY 300s':
+            objtype = 'TAR'
+            recipe_name = 'SKY'
 
         if populate_group1:
             group1 = group["OBSID"].iloc[0]

--- a/igrins/igrins_recipes/recipe_prepare_recipe_logs.py
+++ b/igrins/igrins_recipes/recipe_prepare_recipe_logs.py
@@ -86,7 +86,7 @@ def write_to_file(df_recipe_logs, fn_out):
 
     headers = df_recipe_logs.keys()
     fout.write(", ".join(headers) + "\n")
-    fout.write("# Avaiable recipes : FLAT, SKY, A0V_AB, A0V_ONOFF, "
+    fout.write("# Available recipes : FLAT, SKY, A0V_AB, A0V_ONOFF, "
                "STELLAR_AB, STELLAR_ONOFF, EXTENDED_AB, EXTENDED_ONOFF\n")
 
     df_recipe_logs.to_csv(fout, index=False, header=False)

--- a/igrins/procedures/apertures.py
+++ b/igrins/procedures/apertures.py
@@ -29,7 +29,7 @@ class Apertures(object):
         if (end_order is None) or (end_order < 0):
             end_order = self.orders[-1]
 
-        self.orders_to_extract = range(start_order, end_order+1)
+        self.orders_to_extract = list(range(start_order, end_order+1))
 
     def __init__(self, orders, bottomup_solutions,
                  basename="", order_minmax_to_extract=(-1, -1)):
@@ -176,6 +176,9 @@ class Apertures(object):
         return s_list
 
     def extract_spectra_from_ordermap(self, data, order_map):
+        # FIXME please check is orders_to_extract is propertly respected and
+        # then remove the raise statement
+        raise RuntimeError("This method is not tested.")
         slices = ni.find_objects(order_map)
         s_list = []
         for o in self.orders_to_extract:
@@ -239,6 +242,15 @@ class Apertures(object):
         slices = ni.find_objects(ordermap)
 
         for o in self.orders_to_extract:
+            if o > len(slices) or slices[o-1] is None:
+                s = np.empty(2048, dtype=float)
+                v = np.empty(2048, dtype=float)
+                s.fill(np.nan)
+                v.fill(np.nan)
+                s_list.append(s)
+                v_list.append(v)
+                continue
+
             sl = slices[o-1][0], slice(0, 2048)
             msk = (ordermap[sl] == o)
 
@@ -284,6 +296,15 @@ class Apertures(object):
         #     hl.append(pyfits.PrimaryHDU())
 
         for o in self.orders_to_extract:
+            if o > len(slices) or slices[o-1] is None:
+                s = np.empty(2048, dtype=float)
+                v = np.empty(2048, dtype=float)
+                s.fill(np.nan)
+                v.fill(np.nan)
+                s_list.append(s)
+                v_list.append(v)
+                continue
+
             sl = slices[o-1][0], slice(0, 2048)
             msk = (ordermap_bpixed[sl] == o) & msk1[sl]
 
@@ -627,7 +648,9 @@ class Apertures(object):
         xx = np.arange(2048)
 
         slices = ni.find_objects(order_map)
-        for o, s in zip(self.orders, s_list):
+        for o, s in zip(self.orders_to_extract, s_list):
+            if o > len(slices) or slices[o-1] is None:
+                continue
             sl = slices[o-1][0], slice(0, 2048)
             msk = (order_map[sl] == o)
 

--- a/igrins/procedures/apertures.py
+++ b/igrins/procedures/apertures.py
@@ -624,42 +624,32 @@ class Apertures(object):
 
 
 
-    def make_profile_map(self, order_map, slitpos_map, lsf,
-                         slitoffset_map=None, slice_indicies=(0,2048)):
+    def make_profile_column(self, order_map, slitpos_map, lsf,
+                         slitoffset_map=None, slice_index=0):
         """
-        lsf : callable object which takes (o, x, slit_pos)
-
-        o : order (integer)
-        x : detector position in dispersion direction
-        slit_pos : 0..1
-
-        x and slit_pos can be array.
+        Like make_profile_map above but for a single column in the echellogram
         """
-
         iy, ix = np.indices(slitpos_map.shape)
 
         if slitoffset_map is not None:
-            ix = ix - slitoffset_map
+            ix = ix - slitoffset_map[slice_index,slice_index]
 
-        profile_map = np.empty(slitpos_map.shape, "d")
-        profile_map.fill(np.nan)
+        profile_column = np.empty(slitpos_map.shape[1], "d")
+        profile_column.fill(np.nan)
 
-        slices = ni.find_objects(order_map)
         for o in self.orders:
-            #sl = slices[o-1][0], slice(0, 2048)
-            sl = slices[o-1][0], slice(slice_indicies[0], slice_indicies[1])
-            msk = (order_map[sl] == o)
+            msk = (order_map[:,slice_index] == o)
 
-            profile1 = np.zeros(profile_map[sl].shape, "d")
-            profile1[msk] = lsf(o, ix[sl][msk], slitpos_map[sl][msk])
+            profile1 = np.zeros(profile_column.shape, "d")
+            profile1[msk] = lsf(o, ix[msk], slitpos_map[:,slice_index][msk])
             # TODO :make sure that renormalization is good thing to do.
-            profile_sum = np.abs(profile1).sum(axis=0)
+            profile_sum = np.nansum(np.abs(profile1), axis=0)
             with np.errstate(invalid="ignore"):
                 profile1 /= profile_sum
 
-            profile_map[sl][msk] = profile1[msk]
+            profile_column[msk] = profile1[msk]
 
-        return profile_map
+        return profile_column
 
     def make_synth_map(self, order_map, slitpos_map,
                        profile_map, s_list,

--- a/igrins/procedures/estimate_sky.py
+++ b/igrins/procedures/estimate_sky.py
@@ -56,7 +56,7 @@ def estimate_background(data, msk, di=24, min_pixel=10):
             xc = i0 + sl_x.start + xc_sl
             yc = sl_y.start + yc_sl
 
-            v = np.median(bar_sl[msk_sl])
+            v = np.nanmedian(bar_sl[msk_sl])
             e = (bar_sl[msk_sl] - v)**2
             sky_points.append((xc, yc, v, e.sum()**.5))
 

--- a/igrins/procedures/procedures_flexure_correction.py
+++ b/igrins/procedures/procedures_flexure_correction.py
@@ -71,7 +71,7 @@ def cross_correlate(reference, data, zoom_amount=1000, maximum_pixel_search=10):
 	fft_sub_result_x = fft_result_x[x1:x2]
 
 	#Mask out large trends
-	n = len(fft_sub_result_x)
+	n = len(fft_sub_result_x) 
 	fit_x_array = np.arange(n)
 	fft_sub_result_mask = (fit_x_array < n*0.25) | (fit_x_array > n*0.75)
 	pfit = Polynomial.fit(fit_x_array[fft_sub_result_mask], fft_sub_result_x[fft_sub_result_mask], 2)
@@ -170,6 +170,7 @@ def estimate_flexure(obsset, data, exptime):
 	# if exptime >= 20.0: #Load mask to isolate sky lines , for long exposures estimate flexure for each frame seperately
 	master_cal_dir = obsset.rs.master_ref_loader.config.master_cal_dir
 	mask = (fits.getdata(master_cal_dir+'/'+band+'-band_sky_mask.fits') == 1.0)
+	#mask = (fits.getdata(master_cal_dir+'/'+band+'-band_sky_mask_igrins2.fits') == 1.0)
 	refframe[~mask] = np.nan
 	#for dataframe in data:
 	for i in range(len(data)):
@@ -221,6 +222,7 @@ def estimate_flexure_short_exposures(obsset, data_a, data_b, exptime):
 	refframe = copy.deepcopy(obsset.load_resource_for("flexcorr")[0].data)
 	master_cal_dir = obsset.rs.master_ref_loader.config.master_cal_dir
 	mask = (fits.getdata(master_cal_dir+'/'+band+'-band_limited_sky_mask.fits') == 1.0)  #(note we use a more conservative mask for short exposures)
+	#mask = (fits.getdata(master_cal_dir+'/'+band+'-band_limited_sky_mask_igrins2.fits') == 1.0)  #(note we use a more conservative mask for short exposures)
 	refframe[~mask] = np.nan
 	combined_data = data_a + data_b - np.abs(data_a - data_b)
 	cleaned_combined_data = isolate_sky_lines(combined_data / (exptime * len(obsset.get_obsids()))) #Apply median filters to isolate sky lines from other signal and normalize by exposure time

--- a/igrins/procedures/procedures_register.py
+++ b/igrins/procedures/procedures_register.py
@@ -120,12 +120,15 @@ def _get_offset_transform(thar_spec_src, thar_spec_dst):
         # reduce the search range for correlation peak using the model
         # prediction.
         ym = int(model_robust.predict_y(i))
-        x1 = int(max(0, (center - ym) - 20))
-        x2 = int(min((center - ym) + 20 + 1, 2048))
-        # print i, x1, x2
-        ym2 = center - (np.argmax(cor_list[i][x1:x2]) + x1)
-        # print ym2
-        offsets2[i] = ym2
+        try:  #Error catch in odd instances ThAr registering doesn't fully work
+            x1 = int(max(0, (center - ym) - 20))
+            x2 = int(min((center - ym) + 20 + 1, 2048))
+            # print i, x1, x2
+            ym2 = center - (np.argmax(cor_list[i][x1:x2]) + x1)
+            # print ym2
+            offsets2[i] = ym2
+        except:
+            pass
 
     def get_offsetter(o):
         def _f(x, o=o):

--- a/igrins/procedures/slit_profile.py
+++ b/igrins/procedures/slit_profile.py
@@ -132,32 +132,64 @@ def estimate_slit_profile_1d(obsset,
     ordermap_bpixed = helper.get("ordermap_bpixed")
     slitpos_map = helper.get("slitposmap")
 
-    _ = extract_slit_profile(ap,
-                             ordermap_bpixed, slitpos_map,
-                             data_minus_flattened,
-                             x1=x1, x2=x2)
-    bins, hh0, slit_profile_list = _
+    #Old method for profile determination that uses the entire detector, currently commented out
+    
+    # _ = extract_slit_profile(ap,
+    #                          ordermap_bpixed, slitpos_map,
+    #                          data_minus_flattened,
+    #                          x1=x1, x2=x2)
+    # bins, hh0, slit_profile_list = _
 
-    if do_ab:
-        profile_x, profile_y = _get_norm_profile_ab(bins, hh0)
-        # profile = get_profile_func_ab(profile_x, profile_y)
-    else:
-        profile_x, profile_y = _get_norm_profile(bins, hh0)
-        # profile = get_profile_func(profile_x, profile_y)
+    # if do_ab:
+    #     profile_x, profile_y = _get_norm_profile_ab(bins, hh0)
+    #     # profile = get_profile_func_ab(profile_x, profile_y)
+    # else:
+    #     profile_x, profile_y = _get_norm_profile(bins, hh0)
+    #     # profile = get_profile_func(profile_x, profile_y)
 
-    slit_profile_dict = dict(orders=orders,
-                             ab_mode=do_ab,
-                             slit_profile_list=slit_profile_list,
-                             profile_x=profile_x,
-                             profile_y=profile_y)
+    # slit_profile_dict = dict(orders=orders,
+    #                          ab_mode=do_ab,
+    #                          slit_profile_list=slit_profile_list,
+    #                          profile_x=profile_x,
+    #                          profile_y=profile_y)
 
-    obsset.store("SLIT_PROFILE_JSON", slit_profile_dict,
-                 postfix=obsset.basename_postfix)
+    # obsset.store("SLIT_PROFILE_JSON", slit_profile_dict,
+    #              postfix=obsset.basename_postfix)
 
-    profile = _get_profile_func_from_dict(slit_profile_dict)
-    profile_map = make_slitprofile_map(ap, profile,
-                                       ordermap, slitpos_map,
-                                       frac_slit=frac_slit)
+    # profile = _get_profile_func_from_dict(slit_profile_dict)
+    # profile_map = make_slitprofile_map(ap, profile,
+    #                                    ordermap, slitpos_map,
+    #                                    frac_slit=frac_slit)
+
+
+    #Backport running median per column profile determination from igrins2 branch
+    profile_map = np.zeros([2048, 2048])
+
+    for i in range(2048):
+        x1 = i - 64 #Range +/- 
+        x2 = i + 64
+        if x1 < 0: x1 = 0
+        if x2 > 2048: x2 = 2048
+
+        bins, hh0, slit_profile_list = extract_slit_profile(ap,
+                                 ordermap_bpixed, slitpos_map,
+                                 data_minus_flattened,
+                                 x1=x1, x2=x2,
+                                 #mode='median',
+                                 #mode = 'biweight_location',
+                                 )
+        if do_ab:
+            profile_x, profile_y = _get_norm_profile_ab(bins, hh0)
+        else:
+            profile_x, profile_y = _get_norm_profile(bins, hh0)
+            # profile = get_profile_func(profile_x, profile_y)
+        slit_profile_dict = dict(orders=ap.orders_to_extract,
+                                 ab_mode=do_ab,
+                                 slit_profile_list=slit_profile_list,
+                                 profile_x=profile_x,
+                                 profile_y=profile_y)
+        profile_map[:,i] = ap.make_profile_column(ordermap, slitpos_map, _get_profile_func_from_dict(slit_profile_dict), slice_index=i)
+
 
     hdul = obsset.get_hdul_to_write(([], profile_map))
     obsset.store("slitprofile_fits", hdul, cache_only=True)

--- a/igrins/procedures/target_spec.py
+++ b/igrins/procedures/target_spec.py
@@ -16,7 +16,7 @@ def _get_int_from_config(obsset, kind, default):
 
 
 def setup_extraction_parameters(obsset, order_range="-1,-1",
-                                height_2dspec=0, correct_flexure=False, mask_cosmics=False):
+                                height_2dspec=0, correct_flexure=False, mask_cosmics=False, disable_pattern_removal=False):
 
     _order_range_s = order_range
     try:
@@ -34,7 +34,7 @@ def setup_extraction_parameters(obsset, order_range="-1,-1",
     obsset.set_recipe_parameters(order_start=order_start,
                                  order_end=order_end,
                                  height_2dspec=height_2dspec,
-                                 correct_flexure=correct_flexure, mask_cosmics=mask_cosmics)
+                                 correct_flexure=correct_flexure, mask_cosmics=mask_cosmics, disable_pattern_removal=disable_pattern_removal)
 
 
 def _get_combined_image(obsset):

--- a/igrins/procedures/target_spec.py
+++ b/igrins/procedures/target_spec.py
@@ -305,6 +305,10 @@ def store_1dspec(obsset, v_list, s_list, sn_list=None):
                                     ([], convert_data(wvl_data)))
     wvl_header.update(hdul[0].header)
     hdul[0].header = wvl_header
+
+    hdul[0].header['OBSIDS'] = (obsset.get_obsids_string(), 'All Observation IDs used in stack')
+    hdul[0].header['FRMTYPES'] = (obsset.get_frametypes_string(), 'All Frametypes used in stack (A or B)')
+
     hdul[0].verify(option="silentfix")
 
     obsset.store("SPEC_FITS", hdul,
@@ -370,6 +374,9 @@ def store_2dspec(obsset,
     hdul = obsset.get_hdul_to_write(([], convert_data(d.astype("float32"))))
     # wvl_header.update(hdul[0].header)
     hdul[0].header = wvl_header
+
+    hdul[0].header['OBSIDS'] = (obsset.get_obsids_string(), 'All Observation IDs used in stack')
+    hdul[0].header['FRMTYPES'] = (obsset.get_frametypes_string(), 'All Frametypes used in stack (A or B)') 
 
     obsset.store("SPEC2D_FITS", hdul, postfix=basename_postfix)
 

--- a/igrins/procedures/target_spec.py
+++ b/igrins/procedures/target_spec.py
@@ -16,7 +16,7 @@ def _get_int_from_config(obsset, kind, default):
 
 
 def setup_extraction_parameters(obsset, order_range="-1,-1",
-                                height_2dspec=0, correct_flexure=False, mask_cosmics=False, disable_pattern_removal=False):
+                                height_2dspec=0, correct_flexure=False, mask_cosmics=False, disable_pattern_removal=False, slit_profile_method='column'):
 
     _order_range_s = order_range
     try:
@@ -34,7 +34,7 @@ def setup_extraction_parameters(obsset, order_range="-1,-1",
     obsset.set_recipe_parameters(order_start=order_start,
                                  order_end=order_end,
                                  height_2dspec=height_2dspec,
-                                 correct_flexure=correct_flexure, mask_cosmics=mask_cosmics, disable_pattern_removal=disable_pattern_removal)
+                                 correct_flexure=correct_flexure, mask_cosmics=mask_cosmics, disable_pattern_removal=disable_pattern_removal, slit_profile_method=slit_profile_method)
 
 
 def _get_combined_image(obsset):
@@ -231,13 +231,15 @@ def estimate_slit_profile(obsset,
                           slit_profile_mode="1d",
                           frac_slit=None):
 
+    slit_profile_method = obsset.get_recipe_parameter('slit_profile_method')
+
     if type(frac_slit) is str: #Convert frac slit to list of floats if not already floats
         frac_slit = list(map(float, frac_slit.split(",")))
 
     if slit_profile_mode == "1d":
         from .slit_profile import estimate_slit_profile_1d
         estimate_slit_profile_1d(obsset, x1=x1, x2=x2, do_ab=do_ab,
-                                 frac_slit=frac_slit)
+                                 frac_slit=frac_slit, method=slit_profile_method)
     elif slit_profile_mode == "uniform":
         from .slit_profile import estimate_slit_profile_uniform
         estimate_slit_profile_uniform(obsset, do_ab=do_ab,

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 #Simple script to fully run IGRINS PLP on any UTDATE
+
+SLIT_PROFILE_METHOD=column #Method for determining slit profile for optimal extraction, column=use running median per column across detector (new method, default),  full=use single median profile across entire detector (old method, might be needed for very low SNR targets)
+
 echo "Enter UTDATE:" #Prompt user to enter date
 read UTDATE #Get date from user
 #Clean up previous files, if any
@@ -17,11 +20,11 @@ python ./igr_pipe.py register-sky $UTDATE #First pass at wavelength solution usi
 python ./igr_pipe.py flexure-setup $UTDATE #Setup files needed for flexure correction
 #python ./igr_pipe.py thar $UTDATE #First pass at wavelength solution using ThAr lamps, looks like current PLP version doesn't even use THAR lamp frames
 python ./igr_pipe.py wvlsol-sky $UTDATE #Second pass at wavelength solution using OH sky emission
-python ./igr_pipe.py a0v-ab $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics #Reduce A0V standard star data
-python ./igr_pipe.py a0v-onoff $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics
+python ./igr_pipe.py a0v-ab $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics --slit-profile-method=$SLIT_PROFILE_METHOD #Reduce A0V standard star data
+python ./igr_pipe.py a0v-onoff $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics --slit-profile-method=$SLIT_PROFILE_METHOD
 python ./igr_pipe.py tell-wvsol $UTDATE #Use telluric absorption in A0V std star to fine tune wavelength solution
-python ./igr_pipe.py stellar-ab $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics #Reduce stellar sources nod on slit
-python ./igr_pipe.py stellar-onoff $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics #Reduce stellar sources nod off slit
+python ./igr_pipe.py stellar-ab $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics --slit-profile-method=$SLIT_PROFILE_METHOD #Reduce stellar sources nod on slit
+python ./igr_pipe.py stellar-onoff $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics --slit-profile-method=$SLIT_PROFILE_METHOD #Reduce stellar sources nod off slit
 python ./igr_pipe.py extended-ab $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics #Reduce extended sources nod on slit
 python ./igr_pipe.py extended-onoff $UTDATE --correct-flexure --height-2dspec=100 --mask-cosmics #Reduce extended sources not off slit
 python ./igr_pipe.py divide-a0v $UTDATE #Reduce stellar sources nod off slit


### PR DESCRIPTION
This pull request features two major updates to the IGRINS PLP.  The ability to reduce data with no associated b exposures.  This is done by modifying the pattern removal.  Note that the pattern removal is not as good with no b exposures, and it is recommended you include b (or off) nod exposures when observing.  This is mostly for lab data. 

I also restored the ability of the IGRINS PLP to calculate wavelength solutions from ThAr arc lamp calibration data.  This was a feature in the PLP v2, and the ThAr lamp has not been installed in IGRINS for some time.  This ability is mostly meant for old or lab data.