### PR TITLE
Fix to fits headers for .spec.fits and .spec2d.fits wavelength extens…

### DIFF
--- a/igrins/procedures/target_spec.py
+++ b/igrins/procedures/target_spec.py
@@ -363,7 +363,7 @@ def store_1dspec(obsset, v_list, s_list, postfix='', sn_list=None):
     hdul[3].header['EXTNAME'] = 'SCI'
     hdul[1].header['EXTVER'] = 1
     hdul[2].header['EXTVER'] = 1
-    hdul[3].header['EXTVER'] = 1
+    hdul[3].header['EXTVER'] = 2
     hdul[1].header['EXTDESC'] = 'TGT_SPEC'
     hdul[2].header['EXTDESC'] = 'TGT_SPEC_VARIANCE'
     hdul[3].header['EXTDESC'] = 'WAVELENGTH'    
@@ -488,7 +488,7 @@ def store_2dspec(obsset,
     hdul[3].header['EXTNAME'] = 'SCI'
     hdul[1].header['EXTVER'] = 1
     hdul[2].header['EXTVER'] = 1
-    hdul[3].header['EXTVER'] = 1
+    hdul[3].header['EXTVER'] = 2
     hdul[1].header['EXTDESC'] = 'TGT_SPEC'
     hdul[2].header['EXTDESC'] = 'TGT_SPEC_VARIANCE'
     hdul[3].header['EXTDESC'] = 'WAVELENGTH'    


### PR DESCRIPTION
…tions to set EXTVER=1 to EXTVER=2 since the wavelength solution is not the science data.